### PR TITLE
Switch markdownlint to Node.js to allow error ignoring across file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.29.0
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.5
     hooks:
       - id: markdownlint


### PR DESCRIPTION
Switch to the Node.js markdownlint as described in [pa-aa-toolbox](https://github.com/OCHA-DAP/pa-aa-toolbox/issues/12).