### PR TITLE
add dash

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
         "drought",
         "dry-spells",
         "storms",
-        "infectious disease"
+        "infectious-disease"
     ],
     "status": [
         "under development",


### PR DESCRIPTION
add dash to infectious disease as shock type, cause otherwise get a space in the folder name, which is not handy. 

I am merging directly cause I need it, but can always revert. 