### PR TITLE
Add setup.cfg for install

### DIFF
--- a/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/README.md
+++ b/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/README.md
@@ -54,11 +54,23 @@ The code in this repository is organized as follows:
 
 ## Reproducing this analysis
 
-Create a new virtual environment and install the requirements with
+Create a directory where you would like the data to be stored,
+and point to it using an environment variable called
+`AA_DATA_DIR`.
+
+Next create a new virtual environment and install the requirements with:
 
 ```shell
 pip install -r requirements.txt
 ```
+
+Finally, install any code in `src` using the command:
+
+```shell
+pip install -e .
+```
+
+## Development
 
 All code is formatted according to black and flake8 guidelines.
 The repo is set-up to use pre-commit.
@@ -68,7 +80,8 @@ Before you start developing in this repository, you will need to run
 pre-commit install
 ```
 
-The `markdownlint` hook will require [Ruby](https://www.ruby-lang.org/en/documentation/installation/)
+The `markdownlint` hook will require
+[Ruby](https://www.ruby-lang.org/en/documentation/installation/)
 to be installed on your computer.
 
 You can run all hooks against all your files using
@@ -86,7 +99,3 @@ cleaner diffs (and thus easier code reviews) and will ensure that cell outputs a
 committed to the repo (which might be problematic if working with sensitive data).
 
 {%- endif %}
-
-For baseline datasets, you might also need to sync [this](https://drive.google.com/drive/u/3/folders/1RVpnCUpxHQ-jokV_27xLRqOs6qR_8mqQ)
-directory from Google drive to your local machine.
-Create an environment variable called `AA_DATA_DIR` that points to this directory.

--- a/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/README.md
+++ b/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/README.md
@@ -70,6 +70,21 @@ Finally, install any code in `src` using the command:
 pip install -e .
 ```
 
+To run the pipeline that downloads and processes the data, execute:
+
+```shell
+python src/main.py
+```
+
+To see runtime options, execute:
+
+```shell
+python src/main.py -h
+```
+
+If you would like to instead receive the processed data from our team, please
+[contact us](mailto:centrehumdata@un.org).
+
 ## Development
 
 All code is formatted according to black and flake8 guidelines.

--- a/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/setup.cfg
+++ b/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+name = src
+
+[options]
+packages = src

--- a/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/src/constants.py
+++ b/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/src/constants.py
@@ -1,0 +1,1 @@
+ISO3 = {{cookiecutter.country_iso3}}  # noqa: F821

--- a/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/src/main.py
+++ b/pa-aa-{{cookiecutter.country_iso3}}-{{cookiecutter.shock}}/src/main.py
@@ -1,0 +1,25 @@
+import argparse
+import logging
+
+from src import constants  # noqa: F401
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--clobber", action="store_true")
+    parser.add_argument("-d", "--debug", action="store_true")
+    return parser.parse_args()
+
+
+def run_pipeline(clobber: bool = False):
+    pass
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    run_pipeline(clobber=args.clobber)


### PR DESCRIPTION
- Added pipeline skeleton to `src`
- Amended README:
  - Explain how to install `src`
  - Separate setup to run from development setup 
  - Remove reference to data folder: If there are ever external users, they can either download the data themselves or can contact us as mentioned

Question: Is there a better email address than the general one?